### PR TITLE
Adds `start` script in package.json and spanish prompt & select

### DIFF
--- a/app.js
+++ b/app.js
@@ -245,10 +245,10 @@ function getYouTubeId(link) {
 async function langDet(lang, res) {
     if (lang === "tr") {
         aiSummary = await getAiResponse(`Bu video transkripsiyonunu özetleyebilir misin:${res}.`)
-
     } else if (lang === "en") {
         aiSummary = await getAiResponse(`summarize the transcription of this video?:${res}.`)
-
+    } else if (lang === "es") {
+        aiSummary = await getAiResponse(`Hazme un resumen de la transcripción de este video?:${res}.`)
     }
     return aiSummary
 }

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "main": "index.js",
   "scripts": {
+    "start": "node app.js",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "author": "",

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -131,6 +131,7 @@
         <select id="language-select" name="selectedLanguage" class=" text-white bg-gray-600 absolute inset-y-0 right-0 py-3/2 px-1 rounded-md focus:outline-none ">
             <option value="en">English</option>
             <option value="tr">Turkish</option>
+            <option value="es">Spanish</option>
             <option value="hi">Hindi</option>
             <option value="pt">Portuguese</option>
             <option value="fil">Filipino</option>


### PR DESCRIPTION
It is kind of difficult nowadays to find a youtube video with spanish subtitles. For example this video https://www.youtube.com/watch?v=BVEMVPdHQ5U indeed _has_ spanish CC subtitle you can turn on / off by clicking the CC button

![image](https://github.com/atilaahmettaner/youtube-subtitle-summarizer/assets/3003032/fafe61c6-5615-43c0-b188-87afe82c7798)

But "spanish" is not on the list of subtitles

![image](https://github.com/atilaahmettaner/youtube-subtitle-summarizer/assets/3003032/55e41c20-8431-4262-84c8-f1b4716cad2a)

So lemnoslife API does not scrape the subtitles. However, I think this code changes should be OK to grab the subtitles of other videos.

If you are OK with these changes, I can do another PR to translate the prompt into Portuguese and the other languages you wrote on the HTML view.